### PR TITLE
Doc-string fix

### DIFF
--- a/src/arachne/pedestal/dsl.clj
+++ b/src/arachne/pedestal/dsl.clj
@@ -10,7 +10,7 @@
             [clojure.string :as str]))
 
 (defdsl create-server
-  "Define an Pedestal HTTP server entity with the given Arachne ID and port, in the current
+  "Define an Pedestal HTTP server entity with the given port, in the current
   configuration. Return the tempid of the new server."
   (s/cat :port integer?)
   [port]


### PR DESCRIPTION
- Removed _Arachne ID_ from `create-server` doc-string.