### PR TITLE
No need to call `e/assert-args` in a macro.

### DIFF
--- a/src/arachne/pedestal/dsl.clj
+++ b/src/arachne/pedestal/dsl.clj
@@ -31,7 +31,6 @@
   "Define a Pedestal HTTP server in the current configuration. Evaluates the body with the server
   bound as the context server. Returns the eid of the server component."
   [port & body]
-  (apply e/assert-args `server port body)
   `(let [server-eid# (create-server ~port)]
      (binding [http-dsl/*context-server* server-eid#]
        ~@body)


### PR DESCRIPTION
Macros are [always checked](https://clojure.org/guides/spec#_macros) during macro expansion.

If the intent is to return an Arachne error, then `e/assert-args` but the fn spec needs to be renamed. Although doing that feels icky to me.